### PR TITLE
Comment generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "lib/transform",
   "dependencies": {
-    "recast": "^0.9.18"
+    "recast": "^0.10.0"
   }
 }

--- a/scripts/transform/assertions.js
+++ b/scripts/transform/assertions.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var assert = require('assert');
+var recast = require('recast');
+
+var assertions = {
+	assertThrows: function(path) {
+		var args = path.parentPath.value.arguments;
+
+		assert.equal(args.length, 2, 'Unexected invocation of assertThrows');
+
+		args.unshift(args.pop());
+		path.value.name = 'assert.throws';
+	},
+	assertSame: function(path) {
+		var args = path.parentPath.value.arguments;
+		var expected = args[0];
+
+		assert(args.length > 1 && args.length < 4, 'Unexpected invocation of assertSame');
+
+		args[0] = args[1];
+		args[1] = expected;
+		path.value.name = 'assert.sameValue';
+	},
+	assertTrue: function(path) {
+		path.value.name = 'assert';
+	},
+	assertFalse: function(path) {
+		var args = path.parentPath.value.arguments;
+		if (args.length > 1) {
+			args[2] = args[1];
+		}
+		args[1] = recast.types.builders.literal(false);
+		path.value.name = 'assert.sameValue';
+	},
+	assertNull: function(path) {
+		var args = path.parentPath.value.arguments;
+		if (args.length > 1) {
+			args[2] = args[1];
+		}
+
+		args[1] = recast.types.builders.literal(null);
+		path.value.name = 'assert.sameValue';
+	},
+	assertNotNull: function(path) {
+		var args = path.parentPath.value.arguments;
+		args[0] = recast.types.builders.binaryExpression(
+			'!==', args[0], recast.types.builders.literal(null)
+		);
+
+		path.value.name = 'assert';
+	},
+	assertDoesNothThrough: function() {
+		throw new Error('`assertDoesNotThrow` is not implemented');
+	},
+	assertUnreachable: function(path) {
+		var args = path.parentPath.value.arguments;
+		if (args.length) {
+			args[1] = args[0];
+		}
+		args[0] = recast.types.builders.literal(false);
+		path.value.name = 'assert';
+	},
+	assertArrayEquals: function(path) {
+		var args = path.parentPath.value.arguments;
+		var expected = args[0];
+		var callee = recast.types.builders.identifier('compareArray');
+
+		args[0] = recast.types.builders.callExpression(callee, [
+			expected,
+			args[1]
+		]);
+
+
+		if (args.length === 2) {
+			args.length = 1;
+		} else {
+			args[1] = args.pop();
+		}
+
+		path.value.name = 'assert';
+
+		return { dependencies: ['compareArray'] };
+	}
+};
+
+module.exports = function(ast) {
+	var dependencies = [];
+
+	var visitor = recast.visit(ast, {
+		visitIdentifier: function(path) {
+			var node = path.value;
+			var result;
+
+			if (assertions.hasOwnProperty(node.name)) {
+				if (path.parentPath.value.type !== 'CallExpression') {
+					var callExpr = recast.types.builders.callExpression(path.value, [])
+					var fnExpr = recast.types.builders.functionExpression(
+						null,
+						[],
+						recast.types.builders.blockStatement([
+							recast.types.builders.expressionStatement(
+								callExpr
+							)
+						])
+					);
+
+					return fnExpr;
+				}
+				// We could special cases for different function invocations
+				// patterns, but that would probably be an over-optimization in
+				// this context. Throw an error to prompt manual intervention.
+
+				result = assertions[node.name](path);
+
+				if (result && result.dependencies) {
+					result.dependencies.forEach(function(file) {
+						if (dependencies.indexOf(file) > -1) {
+							return;
+						}
+						dependencies.push(file);
+					});
+				}
+			}
+			this.traverse(path);
+		}
+	});
+
+	return {
+		ast: ast,
+		dependencies: dependencies
+	};
+}

--- a/scripts/transform/comments.js
+++ b/scripts/transform/comments.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function makeFrontMatter(ast, dependencies) {
+	var value = [
+		'es6id: ',
+		'description: >'
+	];
+	var includes;
+
+	if (dependencies.length) {
+		includes = dependencies.map(function(file) {
+			return file + '.js';
+		}).join(', ');
+		value.push('includes: [' + includes + ']');
+	}
+	value = '---\n' + value.join('\n') + '\n---';
+
+	return {
+		type: 'Block',
+		value: value,
+		leading: true,
+		trailing: false
+	};
+}
+
+module.exports = function(ast, options) {
+	ast.program.comments.push(makeFrontMatter(ast, options.dependencies));
+};

--- a/scripts/transform/index.js
+++ b/scripts/transform/index.js
@@ -1,119 +1,16 @@
 'use strict';
 
-var assert = require('assert');
 var recast = require('recast');
 
-var assertions = {
-	assertThrows: function(path) {
-		var args = path.parentPath.value.arguments;
-
-		assert.equal(args.length, 2, 'Unexected invocation of assertThrows');
-
-		args.unshift(args.pop());
-		path.value.name = 'assert.throws';
-	},
-	assertSame: function(path) {
-		var args = path.parentPath.value.arguments;
-		var expected = args[0];
-
-		assert(args.length > 1 && args.length < 4, 'Unexpected invocation of assertSame');
-
-		args[0] = args[1];
-		args[1] = expected;
-		path.value.name = 'assert.sameValue';
-	},
-	assertTrue: function(path) {
-		path.value.name = 'assert';
-	},
-	assertFalse: function(path) {
-		var args = path.parentPath.value.arguments;
-		if (args.length > 1) {
-			args[2] = args[1];
-		}
-		args[1] = recast.types.builders.literal(false);
-		path.value.name = 'assert.sameValue';
-	},
-	assertNull: function(path) {
-		var args = path.parentPath.value.arguments;
-		if (args.length > 1) {
-			args[2] = args[1];
-		}
-
-		args[1] = recast.types.builders.literal(null);
-		path.value.name = 'assert.sameValue';
-	},
-	assertNotNull: function(path) {
-		var args = path.parentPath.value.arguments;
-		args[0] = recast.types.builders.binaryExpression(
-			'!==', args[0], recast.types.builders.literal(null)
-		);
-
-		path.value.name = 'assert';
-	},
-	assertDoesNothThrough: function() {
-		throw new Error('`assertDoesNotThrow` is not implemented');
-	},
-	assertUnreachable: function(path) {
-		var args = path.parentPath.value.arguments;
-		if (args.length) {
-			args[1] = args[0];
-		}
-		args[0] = recast.types.builders.literal(false);
-		path.value.name = 'assert';
-	},
-	assertArrayEquals: function(path) {
-		var args = path.parentPath.value.arguments;
-		var expected = args[0];
-		var callee = recast.types.builders.identifier('compareArray');
-
-		args[0] = recast.types.builders.callExpression(callee, [
-			expected,
-			args[1]
-		]);
-
-
-		if (args.length === 2) {
-			args.length = 1;
-		} else {
-			args[1] = args.pop();
-		}
-
-		path.value.name = 'assert';
-	}
-};
+var transforms = {
+  assertions: require('./assertions'),
+  comments: require('./comments')
+}
 
 module.exports = function(code) {
 	var ast = recast.parse(code);
-
-	var visitor = recast.visit(ast, {
-		names: [],
-		visitIdentifier: function(path) {
-			var node = path.value;
-			this.visitor.names.push(node.name);
-			if (assertions.hasOwnProperty(node.name)) {
-				if (path.parentPath.value.type !== 'CallExpression') {
-					var callExpr = recast.types.builders.callExpression(path.value, [])
-					var fnExpr = recast.types.builders.functionExpression(
-						null,
-						[],
-						recast.types.builders.blockStatement([
-							recast.types.builders.expressionStatement(
-								callExpr
-							)
-						])
-					);
-
-					return fnExpr;
-				}
-				// We could special cases for different function invocations
-				// patterns, but that would probably be an over-optimization in
-				// this context. Throw an error to prompt manual intervention.
-
-				assertions[node.name](path);
-			}
-			this.traverse(path);
-		}
-	});
+	var result = transforms.assertions(ast);
+	transforms.comments(result.ast, { dependencies: result.dependencies });
 
 	return recast.print(ast).code;
-}
+};


### PR DESCRIPTION
Now that Recast 0.10 is out, we can perform operations on comments in the AST. Make some minor improvements to the generated test files, but leave the original comments as-is to allow for human review and explicit removal.

Source:

``` js
// Copyright 2014 the V8 project authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.

// Flags: --foo --bar

assertThrows(function() { throw new Error(); }, Error);
assertArrayEquals([1+1], [2]);
```

Transformed:

``` js
// Copyright 2014 the V8 project authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.

// Flags: --foo --bar

// Copyright (C) Copyright 2014 the V8 project authors. All rights reserved.
// This code is governed by the BSD license found in the LICENSE file.
/*---
es6id: 
description: >
includes: [compareArray.js]
---*/

assert.throws(Error, function() { throw new Error(); });
assert(compareArray([1+1], [2]));
```
