### PR TITLE
Facilitate manual editing of commit messages

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+
+if [[ $EDITOR == "" ]]; then
+  EDITOR=$(git config core.editor)
+fi
+
 # Prepare a commit message that includes a listing of files removed from V8
 MSG_FILE=.git/TEST262_COMMIT_EDITMSG
 
 FILES=$(cd v8-git-mirror; git diff master --name-status | sed 's/^[^D].*$//g' | sed 's/^D\s*//g')
-
 
 cat << EOF > $MSG_FILE
 Import tests from Google V8
@@ -20,7 +25,6 @@ EOF
 
 gits status | sed 's/^/#/' >> $MSG_FILE
 
-EDITOR=$(git config core.editor)
 $EDITOR $MSG_FILE > `tty` < `tty`
 
 gits commit $QUOTED_ARGS --message "$(cat $MSG_FILE)"

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
 
 # Prepare a commit message that includes a listing of files removed from V8
-
-TLDR=""
-
-if [[ "$1" != "" ]]; then
-  TLDR="($1)"
-fi
+MSG_FILE=.git/TEST262_COMMIT_EDITMSG
 
 FILES=$(cd v8-git-mirror; git diff master --name-status | sed 's/^[^D].*$//g' | sed 's/^D\s*//g')
 
-MESSAGE=$(cat <<EOF
-Import tests from Google V8 $TLDR
+
+cat << EOF > $MSG_FILE
+Import tests from Google V8
 
 These tests are derived from the following files within the Google V8
 project:
 
 $FILES
-EOF
-)
 
-gits commit --message "$MESSAGE" $@
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+EOF
+
+gits status | sed 's/^/#/' >> $MSG_FILE
+
+EDITOR=$(git config core.editor)
+$EDITOR $MSG_FILE > `tty` < `tty`
+
+gits commit $QUOTED_ARGS --message "$(cat $MSG_FILE)"


### PR DESCRIPTION
Open the editor that has been configured for the current git user, and
use the resulting text as the commit message for all commits.

This should resolve gh-13
