### PR TITLE
Strip whitespace and comments from commit message

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -27,4 +27,4 @@ gits status | sed 's/^/#/' >> $MSG_FILE
 
 $EDITOR $MSG_FILE > `tty` < `tty`
 
-gits commit $QUOTED_ARGS --message "$(cat $MSG_FILE)"
+gits commit $QUOTED_ARGS --message "$(cat $MSG_FILE)" --cleanup strip


### PR DESCRIPTION
This behavior is git's default when a commit message is supplied via an
editor. When it is specified via a command-line flag (as is the case in
this script), the `cleanup` mechanism must be explicitly specified.
